### PR TITLE
Added new alphabetical_properties option for object properties order

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ The variable `self` is always available.  Look at the __Dependencies__ section b
 
 There is no way to specify property ordering in JSON Schema (although this may change in v5 of the spec).
 
-JSON Editor introduces a new keyword `propertyOrder` for this purpose.  The default property order if unspecified is 1000.  Properties with the same order will use normal JSON key ordering.
+JSON Editor introduces the option `propertyOrder` for this purpose.  The default property order if unspecified is 1000.  Properties with the same propertyOrder will be displayed in the order they are listed in the schema, unless alphabetical_properties is set, in which case the are ordered by their property names (useful for objects with many additional properties).
 
 ```json
 {

--- a/src/editors/object.js
+++ b/src/editors/object.js
@@ -62,12 +62,7 @@ JSONEditor.defaults.editors.object = JSONEditor.AbstractEditor.extend({
     // Sort editors by propertyOrder
     this.property_order = Object.keys(this.editors);
     this.property_order = this.property_order.sort(function(a,b) {
-      var ordera = self.editors[a].schema.propertyOrder;
-      var orderb = self.editors[b].schema.propertyOrder;
-      if(typeof ordera !== "number") ordera = 1000;
-      if(typeof orderb !== "number") orderb = 1000;
-
-      return ordera - orderb;
+      return self.propertyOrderComparator(a,b);
     });
 
     var container;
@@ -270,12 +265,7 @@ JSONEditor.defaults.editors.object = JSONEditor.AbstractEditor.extend({
     // Sort editors by propertyOrder
     this.property_order = Object.keys(this.editors);
     this.property_order = this.property_order.sort(function(a,b) {
-      var ordera = self.editors[a].schema.propertyOrder;
-      var orderb = self.editors[b].schema.propertyOrder;
-      if(typeof ordera !== "number") ordera = 1000;
-      if(typeof orderb !== "number") orderb = 1000;
-
-      return ordera - orderb;
+      return self.propertyOrderComparator(a,b);
     });
   },
   build: function() {
@@ -541,6 +531,11 @@ JSONEditor.defaults.editors.object = JSONEditor.AbstractEditor.extend({
     for (var i = 0; i < container.childNodes.length; i++) {
       var child = container.childNodes[i];
       if (control.propertyOrder < child.propertyOrder) {
+        this.addproperty_list.insertBefore(control, child);
+        control = null;
+        break;
+      }
+      else if(this.options.alphabetical_properties && control.propertyOrder == child.propertyOrder && control.textContent.localeCompare(child.textContent) < 0) {
         this.addproperty_list.insertBefore(control, child);
         control = null;
         break;
@@ -891,5 +886,14 @@ JSONEditor.defaults.editors.object = JSONEditor.AbstractEditor.extend({
     $each(this.editors, function(i,editor) {
       editor.showValidationErrors(other_errors);
     });
+  },
+  propertyOrderComparator: function(a,b) {
+    var ordera = this.editors[a].schema.propertyOrder;
+    var orderb = this.editors[b].schema.propertyOrder;
+    if(typeof ordera !== "number") ordera = 1000;
+    if(typeof orderb !== "number") orderb = 1000;
+    if(this.options.alphabetical_properties && ordera == orderb)
+      return a.localeCompare(b);
+    return ordera - orderb;
   }
 });


### PR DESCRIPTION
New alphabetical_properties option for object editors makes properties that have the same propertyOrder value to be sorted by value name.